### PR TITLE
Reduce empty state padding for mobile footer visibility

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
 
         {/* Empty state */}
         {!ogData && !loading && !error && (
-          <div className="text-center text-neutral-600 py-20 font-extralight text-lg">
+          <div className="text-center text-neutral-600 py-8 font-extralight text-lg">
             Enter a URL above to fetch its OG image
           </div>
         )}


### PR DESCRIPTION
## Summary
- Decreased vertical padding on empty state message from `py-20` to `py-8`
- Fixes footer being cut off on mobile devices

## Test plan
- [ ] View the page on mobile (or use responsive mode in dev tools)
- [ ] Verify footer is fully visible when no OG data is loaded